### PR TITLE
Update book references in endnotes

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -13,19 +13,19 @@
 					<p><i epub:type="se:name.publication.play">Arsène Lupin</i>, play in three acts and four scenes, by Maurice Leblanc and Francis de Croisset. <a href="chapter-4.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-2" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">Arsène Lupin Versus Holmlock Shears</i>, by Maurice Leblanc. <a href="chapter-4.xhtml#noteref-2" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/arsene-lupin-versus-herlock-sholmes/george-morehead">Arsène Lupin Versus Herlock Sholmes</a></i>, by Maurice Leblanc. <a href="chapter-4.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-3" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Seven of Hearts</i>, by Maurice Leblanc. <span epub:type="z3998:roman">II</span>; Arsène Lupin in Prison <a href="chapter-8.xhtml#noteref-3" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>, by Maurice Leblanc. <span epub:type="z3998:roman">II</span>; Arsène Lupin in Prison <a href="chapter-8.xhtml#noteref-3" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-4" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Seven of Hearts</i>. <span epub:type="z3998:roman">IX</span>: Holmlock Shears Arrives Too Late. <a href="chapter-8.xhtml#noteref-4" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>. <span epub:type="z3998:roman">IX</span>: Herlock Sholmes Arrives Too Late. <a href="chapter-8.xhtml#noteref-4" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-5" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Seven of Hearts</i>. <span epub:type="z3998:roman">IV</span>: The Mysterious Railway-passenger. <a href="chapter-8.xhtml#noteref-5" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>. <span epub:type="z3998:roman">IV</span>: The Mysterious Traveller. <a href="chapter-8.xhtml#noteref-5" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-6" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">Arsène Lupin Versus Holmlock Shears</i>, by Maurice Leblanc, Chapter <span epub:type="z3998:roman">V</span>: Kidnapped. <a href="chapter-8.xhtml#noteref-6" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/arsene-lupin-versus-herlock-sholmes/george-morehead">Arsène Lupin Versus Herlock Sholmes</a></i>, by Maurice Leblanc, Chapter <span epub:type="z3998:roman">V</span>: An Abduction. <a href="chapter-8.xhtml#noteref-6" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-7" epub:type="endnote">
 					<p><i epub:type="se:name.publication.play">Arsène Lupin</i>, play in four acts, by Maurice Leblanc and Francis de Croisset. <a href="chapter-8.xhtml#noteref-7" epub:type="backlink">↩</a></p>
@@ -40,7 +40,7 @@
 					<p><i xml:lang="la">Magna porta</i>. <a href="chapter-9.xhtml#noteref-10" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-11" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Exploits of Arsène Lupin</i>. By Maurice Leblanc. <span epub:type="z3998:roman">VI</span>: <i epub:type="se:name.publication.book">The Seven of Hearts</i>. <a href="chapter-10.xhtml#noteref-11" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>. By Maurice Leblanc. <span epub:type="z3998:roman">VI</span>: <i epub:type="se:name.publication.book">The Seven of Hearts</i>. <a href="chapter-10.xhtml#noteref-11" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-12" epub:type="endnote">
 					<p><i epub:type="se:name.publication.play">Arsène Lupin</i>, play in four acts, by Maurice Leblanc and Francis de Croisset. <a href="chapter-10.xhtml#noteref-12" epub:type="backlink">↩</a></p>


### PR DESCRIPTION
As discussed in #2, this adds links in the endnotes to references to Standard Ebooks editions, and updates some references to match the Standard Ebooks titles.